### PR TITLE
Fix AttributeError: 'HTMLParser' object has no attribute 'unescape'

### DIFF
--- a/coursera/utils.py
+++ b/coursera/utils.py
@@ -21,7 +21,11 @@ from xml.sax.saxutils import escape, unescape
 
 import six
 from six import iteritems
-from six.moves import html_parser
+if six.PY34:
+    import html
+else:
+    from six.moves import html_parser
+    html = html_parser.HTMLParser()
 from six.moves.urllib.parse import ParseResult
 from six.moves.urllib_parse import unquote_plus
 
@@ -98,8 +102,7 @@ HTML_UNESCAPE_TABLE = dict((v, k) for k, v in HTML_ESCAPE_TABLE.items())
 
 
 def unescape_html(s):
-    h = html_parser.HTMLParser()
-    s = h.unescape(s)
+    s = html.unescape(s)
     s = unquote_plus(s)
     return unescape(s, HTML_UNESCAPE_TABLE)
 
@@ -114,8 +117,7 @@ def clean_filename(s, minimal_change=False):
     """
 
     # First, deal with URL encoded strings
-    h = html_parser.HTMLParser()
-    s = h.unescape(s)
+    s = html.unescape(s)
     s = unquote_plus(s)
 
     # Strip forbidden characters


### PR DESCRIPTION
Fix AttributeError: 'HTMLParser' object has no attribute 'unescape'